### PR TITLE
Allow to provide default value to getValue function

### DIFF
--- a/src/Service/SiteConfigService.php
+++ b/src/Service/SiteConfigService.php
@@ -69,12 +69,13 @@ class SiteConfigService {
    *
    * @param $siteKey
    * @param $field
+   * @param $defaultValue
    *
    * @return array|mixed
    */
-  public function getValue($siteKey, $field) {
+  public function getValue($siteKey, $field, $defaultValue = NULL) {
     if (empty($siteKey) || !$this->siteConfigManager->hasDefinition($siteKey)) {
-      return [];
+      return $defaultValue;
     }
     try {
       /** @var \Drupal\site_config\SiteConfigInterface $plugin */
@@ -83,7 +84,7 @@ class SiteConfigService {
     }
     catch (PluginException $e) {
       \Drupal::logger('site_config')->error($e->getMessage());
-      return [];
+      return $defaultValue;
     }
   }
 


### PR DESCRIPTION
### Changelog
Change default value from `[]` to `NULL`
Allow getValue function to be provided by a custom default value